### PR TITLE
[TASK03] feat: Implement "Tags" for "Product" entity 

### DIFF
--- a/src/api/dto/ProductDTO.ts
+++ b/src/api/dto/ProductDTO.ts
@@ -1,8 +1,11 @@
 import { CategoryDTO } from './CategoryDTO';
+import { TagDTO } from './TagDTO';
+
 export interface ProductDTO {
   id?: string;
   name: string;
   categoryId?: string;
   description?: string;
   category?: CategoryDTO;
+  tags?: TagDTO[];
 }

--- a/src/api/dto/TagDTO.ts
+++ b/src/api/dto/TagDTO.ts
@@ -1,0 +1,4 @@
+export interface TagDTO {
+  id?: string;
+  name: string;
+}

--- a/src/api/endpoints/TagCRUD.ts
+++ b/src/api/endpoints/TagCRUD.ts
@@ -1,0 +1,8 @@
+import { CrudEndpoint } from '../common/CrudEndpoint';
+import { TagDTO } from '../dto/TagDTO';
+
+export class TagCRUD extends CrudEndpoint<TagDTO> {
+  constructor() {
+    super('tags');
+  }
+}

--- a/src/api/utils/GetClient.ts
+++ b/src/api/utils/GetClient.ts
@@ -1,10 +1,12 @@
 import { ICrudEndpoint } from '../../api/common/CrudEndpoint';
 import { CategoryCRUD } from '../endpoints/CategoryCRUD';
 import { ProductCRUD } from '../endpoints/ProductCRUD';
+import { TagCRUD } from '../endpoints/TagCRUD';
 import { EntityType } from '../../store/entityModules/types';
 
 let categoryClient: CategoryCRUD;
 let productClient: ProductCRUD;
+let tagClient: TagCRUD;
 
 export function getEntityApiClient(entityType: EntityType): ICrudEndpoint<any> {
   switch (entityType) {
@@ -14,6 +16,9 @@ export function getEntityApiClient(entityType: EntityType): ICrudEndpoint<any> {
     case EntityType.PRODUCT:
       if (!productClient) productClient = new ProductCRUD();
       return productClient;
+    case EntityType.TAG:
+      if (!tagClient) tagClient = new TagCRUD();
+      return tagClient;
     default:
       throw Error(`No matching API client found for ${entityType}!`);
   }

--- a/src/components/common/EntityTable.vue
+++ b/src/components/common/EntityTable.vue
@@ -89,6 +89,14 @@
             <slot> {{ item.columns.price }}$ </slot>
           </template>
 
+          <template #[`item.tags`]="{ item }">
+            <v-chip-group v-for="tagId in item.columns.tags" :key="tagId">
+              <v-chip>
+                <slot name="tagChipContent" :tagId="tagId"></slot>
+              </v-chip>
+            </v-chip-group>
+          </template>
+
           <template #[`item.totalPrice`]="{ item }">
             <slot> {{ item.columns.totalPrice }}$ </slot>
           </template>

--- a/src/components/entities/products/ProductPage.vue
+++ b/src/components/entities/products/ProductPage.vue
@@ -42,6 +42,22 @@
               data-test="product-categoryId"
             />
           </v-col>
+          <v-col cols="12">
+            <v-combobox
+              :model-value="selectedTags"
+              @update:modelValue="handleTagChange"
+              :items="listTag"
+              item-title="name"
+              item-value="id"
+              chips
+              closable-chips
+              clearable
+              multiple
+              solo
+              label="Tags"
+              variant="outlined"
+            />
+          </v-col>
         </v-row>
       </div>
     </template>
@@ -50,10 +66,11 @@
 
 <script lang="ts">
 import EntityPage from '@/components/common/EntityPage.vue';
-import { defineComponent, onBeforeMount, reactive, watch, computed, ref, Ref } from 'vue';
+import { computed, defineComponent, onBeforeMount, reactive, ref, Ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 import { Product } from '../../../models/entities/Product';
+import { Tag } from '../../../models/entities/Tag';
 
 interface State {
   entity: Product;
@@ -80,6 +97,7 @@ const Component = defineComponent({
     const product = new Product({});
     const isNew = () => !props.id;
     let listCategory: Ref<string[]> = ref([]);
+    let listTag: Ref<Tag[]> = ref([]);
     onBeforeMount(async () => {
       if (!isNew()) {
         const res = await store.dispatch(`productsModule/fetchItem`, props.id);
@@ -87,6 +105,10 @@ const Component = defineComponent({
       }
       listCategory.value = await store.dispatch(
         'categoriesModule/fetchAllItems',
+        undefined,
+      );
+      listTag.value = await store.dispatch(
+        'tagsModule/fetchAllItems',
         undefined,
       );
     });
@@ -106,9 +128,17 @@ const Component = defineComponent({
       const getSelectedItem = store.getters['productsModule/selectedItem'];
       return getSelectedItem.name;
     });
+    const selectedTags = computed(() => {
+      return state.entity.tags.map((tagId) => {
+        return listTag.value.find(tag => tag.id === tagId);
+      });
+    });
     const rules = {
       name: [(v: string) => !!v || 'Name is required'],
     };
+    function handleTagChange(selectedItems: Tag[]) {
+      state.entity.tags = selectedItems.map(item => item.id);
+    }
 
     return {
       state,
@@ -116,6 +146,10 @@ const Component = defineComponent({
       rules,
       isNew,
       listCategory,
+      listTag,
+
+      selectedTags,
+      handleTagChange,
     };
   },
 });

--- a/src/components/entities/products/ProductTable.vue
+++ b/src/components/entities/products/ProductTable.vue
@@ -1,11 +1,17 @@
 <template>
-  <EntityTable :entity-type="entityType" :headers="state.headers" />
+  <EntityTable :entity-type="entityType" :headers="state.headers">
+    <template #tagChipContent="{tagId}">
+      {{ mapTagIdToTagName.get(tagId) ?? '?' }}
+    </template>
+  </EntityTable>
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive } from 'vue';
+import { computed, defineComponent, onBeforeMount, reactive, ref, Ref } from 'vue';
+import { useStore } from 'vuex';
 import { EntityType } from '../../../store/entityModules/types';
 import EntityTable from '../../common/EntityTable.vue';
+import { Tag } from '../../../models/entities/Tag';
 
 const Component = defineComponent({
   name: 'ProductTable',
@@ -15,20 +21,39 @@ const Component = defineComponent({
   },
 
   setup() {
+    const store = useStore();
     const entityType = EntityType.PRODUCT;
+
+    let listTag: Ref<Tag[]> = ref([]);
+    onBeforeMount(async () => {
+      listTag.value = await store.dispatch(
+        'tagsModule/fetchAllItems',
+        undefined,
+      );
+    });
 
     const state = reactive({
       headers: [
         { title: 'Name', key: 'name', sortable: true, searchable: true },
         { title: 'Category ID', key: 'categoryId', sortable: true },
         { title: 'Description', key: 'description', sortable: false },
+        { title: 'Tags', key: 'tags', sortable: false },
         { title: 'Details', key: 'actions', sortable: false },
       ],
+    });
+
+    const mapTagIdToTagName = computed(() => {
+      const map = new Map();
+      listTag.value.forEach((tag) => {
+        map.set(tag.id, tag.name);
+      });
+      return map;
     });
 
     return {
       entityType,
       state,
+      mapTagIdToTagName,
     };
   },
 });

--- a/src/components/entities/tags/TagDialog.vue
+++ b/src/components/entities/tags/TagDialog.vue
@@ -1,0 +1,108 @@
+<template>
+  <EntityDialog
+    entity-type="tag"
+    :title="title"
+    :item="state.entity"
+    :loading="state.loading"
+    :is-new="isNew()"
+    :is-deletable="!isNew()"
+  >
+    <template #form-content>
+      <div>
+        <v-row align="start">
+          <v-col cols="12">
+            <v-text-field
+              v-model="state.entity.name"
+              label="Name"
+              variant="outlined"
+              required
+              hide-details="auto"
+              :rules="rules.name"
+            />
+          </v-col>
+        </v-row>
+      </div>
+    </template>
+  </EntityDialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, onBeforeMount, reactive, watch, computed, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useStore } from 'vuex';
+import EntityDialog from '@/components/common/EntityDialog.vue';
+import { Tag } from '../../../models/entities/Tag';
+
+interface State {
+  entity: Tag;
+  loading: boolean;
+}
+
+const Component = defineComponent({
+  name: 'TagDialog',
+
+  components: {
+    EntityDialog,
+  },
+
+  props: {
+    id: {
+      type: String,
+      default: '',
+    },
+  },
+
+  setup(props) {
+    const tag = new Tag({});
+    const store = useStore();
+    const router = useRouter();
+    const isNew = () => !props.id;
+
+    let listCategory = ref(<Tag[]>[]);
+
+    onBeforeMount(async () => {
+      if (!isNew()) {
+        const res = await store.dispatch('tagsModule/fetchItem', props.id);
+        if (!res) router.back();
+      }
+      listCategory.value = await store.dispatch(
+        'tagsModule/fetchAllItems',
+        undefined,
+      );
+    });
+
+    const state = reactive({
+      entity: tag,
+      loading: computed(() => store.getters['tagsModule/loading']),
+    }) as State;
+
+    watch(
+      () => store.getters['tagsModule/selectedItem'],
+      (newValue: Tag) => Object.assign(tag, newValue),
+      { immediate: false, deep: true },
+    );
+
+    const title = computed(() => {
+      if (state.loading) return '';
+      if (isNew()) return 'New tag';
+      const getSelectedItem = store.getters['tagsModule/selectedItem'];
+      return getSelectedItem.name;
+    });
+
+    const rules = {
+      name: [(v: string) => !!v || 'Name is required'],
+    };
+
+    return {
+      state,
+      title,
+      rules,
+      isNew,
+      listCategory,
+    };
+  },
+});
+export default Component;
+</script>
+
+<style scoped></style>

--- a/src/components/entities/tags/TagTable.vue
+++ b/src/components/entities/tags/TagTable.vue
@@ -1,0 +1,36 @@
+<template>
+  <EntityTable :entity-type="entityType" :headers="state.headers" />
+</template>
+
+<script lang="ts">
+import { defineComponent, reactive } from 'vue';
+import { EntityType } from '../../../store/entityModules/types';
+import EntityTable from '../../common/EntityTable.vue';
+
+const Component = defineComponent({
+  name: 'TagTable',
+
+  components: {
+    EntityTable,
+  },
+
+  setup() {
+    const entityType = EntityType.TAG;
+
+    const state = reactive({
+      headers: [
+        { title: 'Name', key: 'name', searchable: true },
+        { title: 'Details', key: 'actions', align: 'end', sortable: false },
+      ],
+    });
+
+    return {
+      entityType,
+      state,
+    };
+  },
+});
+export default Component;
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/models/entities/Product.ts
+++ b/src/models/entities/Product.ts
@@ -5,6 +5,7 @@ export class Product implements Entity {
   public name = '';
   public categoryId = '';
   public description = '';
+  public tags?: string[] = []
 
   constructor(initData: Partial<Product>) {
     Object.assign(this, initData);

--- a/src/models/entities/Tag.ts
+++ b/src/models/entities/Tag.ts
@@ -1,0 +1,10 @@
+import Entity from './Entity';
+
+export class Tag implements Entity {
+  public id?: string;
+  public name = '';
+
+  constructor(initData: Partial<Tag>) {
+    Object.assign(this, initData);
+  }
+}

--- a/src/models/mappers/TagMapper.ts
+++ b/src/models/mappers/TagMapper.ts
@@ -1,0 +1,14 @@
+import { mapValueToInterface } from '../../utils/models';
+import { Tag } from '../entities/Tag';
+import { TagDTO } from '../../api/dto/TagDTO';
+import Mapper from './Mapper';
+
+export class TagMapper extends Mapper<Tag, TagDTO> {
+  mapFromDTO(tagDTO: TagDTO): Tag {
+    return new Tag(<Partial<Tag>>tagDTO);
+  }
+
+  mapToDTO(tag: Tag): TagDTO {
+    return mapValueToInterface(tag) as TagDTO;
+  }
+}

--- a/src/models/mappers/utils.ts
+++ b/src/models/mappers/utils.ts
@@ -1,10 +1,12 @@
 import Mapper from './Mapper';
 import { EntityType } from '../../store/entityModules/types';
-import { CategoryMapper } from '../../models/mappers/CategoryMapper';
-import { ProductMapper } from '../../models/mappers/ProductMapper';
+import { CategoryMapper } from './CategoryMapper';
+import { ProductMapper } from './ProductMapper';
+import { TagMapper } from './TagMapper';
 
 let categoryMapper: CategoryMapper;
 let productMapper: ProductMapper;
+let tagMapper: TagMapper;
 
 export function getEntityMapper(entityType: EntityType): Mapper<Object, Object> {
   switch (entityType) {
@@ -14,6 +16,9 @@ export function getEntityMapper(entityType: EntityType): Mapper<Object, Object> 
     case EntityType.PRODUCT:
       if (!productMapper) productMapper = new ProductMapper();
       return productMapper;
+    case EntityType.TAG:
+      if (!tagMapper) tagMapper = new TagMapper();
+      return tagMapper;
     default:
       throw Error(`No matching mapper found for ${entityType}!`);
   }

--- a/src/router/sidebarRoutes.ts
+++ b/src/router/sidebarRoutes.ts
@@ -5,6 +5,9 @@ import CategoryDialog from '../components/entities/categories/CategoryDialog.vue
 
 import ProductTable from '../components/entities/products/ProductTable.vue';
 
+import TagTable from '../components/entities/tags/TagTable.vue';
+import TagDialog from '../components/entities/tags/TagDialog.vue';
+
 const routes: RouteRecordRaw[] = [
   {
     path: '/products',
@@ -46,6 +49,41 @@ const routes: RouteRecordRaw[] = [
         },
         meta: {
           title: 'Category',
+        },
+        props: { default: false, editDialog: true },
+      },
+    ],
+  },
+
+  {
+    path: '/tags',
+    component: TagTable,
+    name: 'Tags-Item',
+    meta: {
+      title: 'Tags',
+      icon: 'mdi-tag',
+      isSideBarIncludes: true,
+    },
+    children: [
+      {
+        path: 'new',
+        components: {
+          default: TagTable,
+          editDialog: TagDialog,
+        },
+        meta: {
+          title: 'New tag',
+        },
+        props: { default: false, editDialog: false },
+      },
+      {
+        path: ':id',
+        components: {
+          default: TagTable,
+          editDialog: TagDialog,
+        },
+        meta: {
+          title: 'Tag',
         },
         props: { default: false, editDialog: true },
       },

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -3,6 +3,7 @@ import { createStore } from 'vuex';
 import authModule from './modules/AuthModule';
 import categoriesModule from './entityModules/CategoriesModule';
 import productsModule from './entityModules/ProductsModule';
+import tagsModule from './entityModules/TagsModule';
 import uiModule from './modules/UIModule';
 
 import createPersistedState from 'vuex-persistedstate';
@@ -16,6 +17,7 @@ const store = createStore({
     authModule,
     categoriesModule,
     productsModule,
+    tagsModule,
     uiModule,
   },
   plugins: [

--- a/src/store/entityModules/TagsModule.ts
+++ b/src/store/entityModules/TagsModule.ts
@@ -1,0 +1,64 @@
+import { TagDTO } from '../../api/dto/TagDTO';
+import { ITableHeader } from '../../models/filters/Filters';
+import { SearchQueryFilters } from '../../models/filters/SearchQueryFilters';
+import { Tag } from '../../models/entities/Tag';
+import { CrudModule } from './CrudModule';
+import { EntityType } from './types';
+
+class TagsModule extends CrudModule<Tag, TagDTO> {
+  constructor() {
+    super();
+    this.state = {
+      ...this.state,
+      entityType: EntityType.TAG,
+      queryFilters: new SearchQueryFilters({}),
+    };
+
+    this.getters = {
+      ...this.getters,
+
+      getItem: state => (id: string) => {
+        const item = state.items.find((i: Tag) => i.id === id);
+        return item || null;
+      },
+
+      getSearchValue(state): string | null {
+        const filter = state.queryFilters as SearchQueryFilters;
+        if (!filter.searchFilter) return null;
+        return filter.searchFilter.value || null;
+      },
+
+      getSearchHeaders(state): ITableHeader[] {
+        const filter = state.queryFilters as SearchQueryFilters;
+        if (!filter.searchFilter) return [];
+        return filter.searchFilter.headers;
+      },
+    };
+
+    this.actions = {
+      ...this.actions,
+
+      setSearchValue({ getters, commit }, value: string | null) {
+        commit('setQueryFilters', {
+          searchFilter: {
+            value,
+            headers: getters.getSearchHeaders,
+          },
+          // show results from the 1st page
+          page: 1,
+        });
+      },
+
+      setSearchHeaders({ commit }, value: ITableHeader[]) {
+        commit('setQueryFilters', {
+          searchFilter: {
+            headers: value,
+          },
+        });
+      },
+    };
+  }
+}
+
+const tagsModule = new TagsModule();
+export default tagsModule;

--- a/src/store/entityModules/types.ts
+++ b/src/store/entityModules/types.ts
@@ -1,6 +1,7 @@
 export enum EntityType {
   PRODUCT = 'product',
   CATEGORY = 'category',
+  TAG = 'tag',
 
   // fallback option (base type) used in CrudModule
   ENTITY = 'entity',

--- a/src/store/entityModules/utils.ts
+++ b/src/store/entityModules/utils.ts
@@ -6,6 +6,8 @@ export function getEntityStorePath(entityType: EntityType): string {
       return 'productsModule';
     case EntityType.CATEGORY:
       return 'categoriesModule';
+    case EntityType.TAG:
+      return 'tagsModule';
     default:
       console.error('No entity module matches provided entity type');
       return '';


### PR DESCRIPTION
### Roadmap
1. **Created** DTO, model, endpoint, Mapper, StoreModule and controller: named `Tag`.
_Tag entity is used as `tags` property of the `Product` entity to set **Draft**, **Needed Review** and etc statuses of Product_
2. **Added** route `tags`: this route is used to manage `Tag` entities i.e. **CREATE, UPDATE, DELETE** entities
3. **Added** components: `TagsTable` and `TagsDialog` to list all the tags and to Create, Update a tag – all are used in the newly created `tags` route.
4. **Updated** `Store`, `utils`, `GetClient`: registered `tags` entity in these modules
5. **Updated** component `ProductPage`: added `tags` input
6. **Updated** component `ProductTable`: added slot to handle each product's `tag` name by Tag id.
```
PS for point 6: I was looking for different ways of implementing fetching Tag names for each Product, e.g.:
1. set "include" filter for product entities by default to fetch relations on "tags" property, but encountered errors during the implementation, and also was concerned by the possible need to keep "tags" property of Product model type "object" all the time that could be complicated
2. fetch in "ProductTable" component and pass through props for "EntityTable"
3. add function prop for "EntityTable" named "getTagNameById"

But decided to leave as it is – via slot.
Though while reflexing on this at the moment, I more like the variant 2:
3. add function prop for "EntityTable" named "getTagNameById"
```
